### PR TITLE
Ignore Picture-In-Picture

### DIFF
--- a/src/resources/config.yaml
+++ b/src/resources/config.yaml
@@ -101,6 +101,9 @@ window_rules:
     name: "keyviz"
     enabled: false
 
+  - match: "Title"
+    name: "Picture-in-Picture"
+    enabled: false
   # EXAMPLE CONFIGURATION:
   # - match: "Class"               # Currently supports "Class" or "Title"
   #   name: "MozillaWindowClass"   # Name of the class or title


### PR DESCRIPTION
Feel free to decline this PR if you don't want this by default, but I found the borders to be annoying/way oversized/distracting in tiny picture-in-picture windows, so I think it's best to disable them. (tested and working with Firefox)