### PR TITLE
feat: replaced animation config format + active window change logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,6 +687,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,16 +1105,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yml"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
 dependencies = [
  "indexmap",
  "itoa",
+ "libyml",
+ "memchr",
  "ryu",
  "serde",
- "unsafe-libyaml",
+ "version_check",
 ]
 
 [[package]]
@@ -1183,7 +1195,7 @@ dependencies = [
  "open",
  "regex",
  "serde",
- "serde_yaml",
+ "serde_yml",
  "sp_log",
  "tray-icon",
  "windows",
@@ -1343,12 +1355,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "version-compare"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -319,7 +319,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -477,7 +477,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -550,7 +550,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -997,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1067,22 +1067,22 @@ checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -1130,9 +1130,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "sp_log"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2c4e10f88f8679fa4f57fe88ae4fb6f409877a017e5246c9b805579554a255"
+checksum = "13c76184bea34353eb7732874aebfa65b23a6053ab342dc0a53abcb842f85be8"
 dependencies = [
  "log",
  "termcolor",
@@ -1151,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.91"
+version = "2.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
+checksum = "9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1222,7 +1222,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -1430,7 +1430,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -1441,7 +1441,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.93",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-serde = "1.0.216"
+serde = "1.0.217"
 serde_yaml = "0.9.34"
 tray-icon = "0.19.2"
 open = "5.3.1"
@@ -12,28 +12,28 @@ dirs = "5.0.1"
 regex = "1.11.1"
 log = "0.4.22"
 anyhow = "1.0.95"
-sp_log = "0.2.0"
+sp_log = "0.2.1"
 
 [dependencies.windows]
 version = "0.58.0"
 features = [
-    "Win32_Foundation",
-    "Foundation_Numerics",
-    "Win32_Graphics_Dwm",
-    "Win32_Graphics_Gdi",
-    "Win32_Graphics_Direct2D",
-    "Win32_Graphics_Direct2D_Common",
-    "Win32_Graphics_Dxgi_Common",
-    "Win32_System_Threading",
-    "Win32_UI_Accessibility",
-    "Win32_UI_HiDpi",
-    "Win32_UI_Input_Ime",
-    "Win32_UI_WindowsAndMessaging",
-    "Win32_System_SystemServices",
-    "Win32_System_LibraryLoader",
-    "Win32_Security",
-    "Win32_System_IO",
-    "Win32_Storage_FileSystem",
+  "Win32_Foundation",
+  "Foundation_Numerics",
+  "Win32_Graphics_Dwm",
+  "Win32_Graphics_Gdi",
+  "Win32_Graphics_Direct2D",
+  "Win32_Graphics_Direct2D_Common",
+  "Win32_Graphics_Dxgi_Common",
+  "Win32_System_Threading",
+  "Win32_UI_Accessibility",
+  "Win32_UI_HiDpi",
+  "Win32_UI_Input_Ime",
+  "Win32_UI_WindowsAndMessaging",
+  "Win32_System_SystemServices",
+  "Win32_System_LibraryLoader",
+  "Win32_Security",
+  "Win32_System_IO",
+  "Win32_Storage_FileSystem",
 ]
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 serde = "1.0.217"
-serde_yaml = "0.9.34"
+serde_yml = "0.0.12"
 tray-icon = "0.19.2"
 open = "5.3.1"
 dirs = "5.0.1"
@@ -17,23 +17,23 @@ sp_log = "0.2.1"
 [dependencies.windows]
 version = "0.58.0"
 features = [
-  "Win32_Foundation",
-  "Foundation_Numerics",
-  "Win32_Graphics_Dwm",
-  "Win32_Graphics_Gdi",
-  "Win32_Graphics_Direct2D",
-  "Win32_Graphics_Direct2D_Common",
-  "Win32_Graphics_Dxgi_Common",
-  "Win32_System_Threading",
-  "Win32_UI_Accessibility",
-  "Win32_UI_HiDpi",
-  "Win32_UI_Input_Ime",
-  "Win32_UI_WindowsAndMessaging",
-  "Win32_System_SystemServices",
-  "Win32_System_LibraryLoader",
-  "Win32_Security",
-  "Win32_System_IO",
-  "Win32_Storage_FileSystem",
+    "Win32_Foundation",
+    "Foundation_Numerics",
+    "Win32_Graphics_Dwm",
+    "Win32_Graphics_Gdi",
+    "Win32_Graphics_Direct2D",
+    "Win32_Graphics_Direct2D_Common",
+    "Win32_Graphics_Dxgi_Common",
+    "Win32_System_Threading",
+    "Win32_UI_Accessibility",
+    "Win32_UI_HiDpi",
+    "Win32_UI_Input_Ime",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_System_SystemServices",
+    "Win32_System_LibraryLoader",
+    "Win32_Security",
+    "Win32_System_IO",
+    "Win32_Storage_FileSystem",
 ]
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,20 +17,23 @@ sp_log = "0.2.0"
 [dependencies.windows]
 version = "0.58.0"
 features = [
-  "Win32_Foundation",
-  "Foundation_Numerics",
-  "Win32_Graphics_Dwm",
-  "Win32_Graphics_Gdi",
-  "Win32_Graphics_Direct2D",
-  "Win32_Graphics_Direct2D_Common",
-  "Win32_Graphics_Dxgi_Common",
-  "Win32_System_Threading",
-  "Win32_UI_Accessibility",
-  "Win32_UI_HiDpi",
-  "Win32_UI_Input_Ime",
-  "Win32_UI_WindowsAndMessaging",
-  "Win32_System_SystemServices",
-  "Win32_System_LibraryLoader",
+    "Win32_Foundation",
+    "Foundation_Numerics",
+    "Win32_Graphics_Dwm",
+    "Win32_Graphics_Gdi",
+    "Win32_Graphics_Direct2D",
+    "Win32_Graphics_Direct2D_Common",
+    "Win32_Graphics_Dxgi_Common",
+    "Win32_System_Threading",
+    "Win32_UI_Accessibility",
+    "Win32_UI_HiDpi",
+    "Win32_UI_Input_Ime",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_System_SystemServices",
+    "Win32_System_LibraryLoader",
+    "Win32_Security",
+    "Win32_System_IO",
+    "Win32_Storage_FileSystem",
 ]
 
 [build-dependencies]

--- a/src/animations.rs
+++ b/src/animations.rs
@@ -26,12 +26,12 @@ impl AnimationsConfig {
             active: self
                 .active
                 .iter()
-                .map(|config| config.to_anim_params())
+                .map(|params_config| params_config.to_anim_params())
                 .collect(),
             inactive: self
                 .inactive
                 .iter()
-                .map(|config| config.to_anim_params())
+                .map(|params_config| params_config.to_anim_params())
                 .collect(),
             fps: self.fps,
             ..Default::default()

--- a/src/animations.rs
+++ b/src/animations.rs
@@ -5,15 +5,19 @@ use std::time;
 use windows::Foundation::Numerics::Matrix3x2;
 
 use crate::anim_timer::AnimationTimer;
+use crate::border_config::serde_default_i32;
 use crate::utils::cubic_bezier;
 use crate::window_border::WindowBorder;
 
 #[derive(Debug, Default, Clone, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct AnimationsConfig {
-    pub active: Option<Vec<AnimParamsConfig>>,
-    pub inactive: Option<Vec<AnimParamsConfig>>,
-    pub fps: Option<i32>,
+    #[serde(default)]
+    pub active: Vec<AnimParamsConfig>,
+    #[serde(default)]
+    pub inactive: Vec<AnimParamsConfig>,
+    #[serde(default = "serde_default_i32::<60>")]
+    pub fps: i32,
 }
 
 impl AnimationsConfig {
@@ -21,19 +25,15 @@ impl AnimationsConfig {
         Animations {
             active: self
                 .active
-                .clone()
-                .unwrap_or_default()
-                .into_iter()
+                .iter()
                 .map(|config| config.to_anim_params())
                 .collect(),
             inactive: self
                 .inactive
-                .clone()
-                .unwrap_or_default()
-                .into_iter()
+                .iter()
                 .map(|config| config.to_anim_params())
                 .collect(),
-            fps: self.fps.unwrap_or(60),
+            fps: self.fps,
             ..Default::default()
         }
     }
@@ -164,7 +164,7 @@ impl AnimEasing {
     /// Converts the easing to a corresponding array of points.
     /// Linear and named easing variants will return predefined control points,
     /// while CubicBezier returns its own array.
-    pub fn to_points(&self) -> [f32; 4] {
+    pub fn to_points(self) -> [f32; 4] {
         match self {
             // Linear
             AnimEasing::Linear => [0.0, 0.0, 1.0, 1.0],
@@ -203,7 +203,7 @@ impl AnimEasing {
             AnimEasing::EaseInOutBack => [0.68, -0.6, 0.32, 1.6],
 
             // CubicBezier variant returns its own points.
-            AnimEasing::CubicBezier(bezier) => *bezier,
+            AnimEasing::CubicBezier(bezier) => bezier,
         }
     }
 }

--- a/src/animations.rs
+++ b/src/animations.rs
@@ -92,7 +92,6 @@ impl std::fmt::Debug for AnimParams {
         f.debug_struct("AnimParams")
             .field("type", &self.anim_type)
             .field("duration", &self.duration)
-            // TODO idk what to put here for "easing"
             .field("easing_fn", &Arc::as_ptr(&self.easing_fn))
             .finish()
     }

--- a/src/border_config.rs
+++ b/src/border_config.rs
@@ -204,7 +204,7 @@ impl Config {
             // Reconvert isize back to HANDLE
             let dir_handle = HANDLE(dir_handle_isize as _);
 
-            let mut buffer = [0u8; 256];
+            let mut buffer = [0u8; 1024];
             let mut bytes_returned = 0u32;
 
             let mut now = time::Instant::now();
@@ -238,7 +238,7 @@ impl Config {
         Ok(())
     }
 
-    fn process_dir_change_notifs(buffer: &[u8; 256], bytes_returned: u32) {
+    fn process_dir_change_notifs(buffer: &[u8; 1024], bytes_returned: u32) {
         let mut offset = 0usize;
 
         while offset < bytes_returned as usize {

--- a/src/border_config.rs
+++ b/src/border_config.rs
@@ -1,16 +1,31 @@
 use crate::animations::Animations;
 use crate::colors::ColorConfig;
-use crate::utils::{get_adjusted_radius, get_window_corner_preference};
+use crate::reload_borders;
+use crate::utils::{get_adjusted_radius, get_window_corner_preference, LogIfErr};
 use anyhow::{anyhow, Context};
 use dirs::home_dir;
 use serde::{Deserialize, Serialize};
+use std::cell::Cell;
 use std::fs::{self, DirBuilder};
+use std::os::windows::ffi::OsStrExt;
 use std::path::PathBuf;
 use std::sync::{LazyLock, RwLock};
-use windows::Win32::Foundation::HWND;
+use std::{iter, ptr, slice, thread, time};
+use windows::core::PCWSTR;
+use windows::Win32::Foundation::{CloseHandle, FALSE, HANDLE, HWND};
 use windows::Win32::Graphics::Dwm::{
     DWMWCP_DEFAULT, DWMWCP_DONOTROUND, DWMWCP_ROUND, DWMWCP_ROUNDSMALL,
 };
+use windows::Win32::Storage::FileSystem::{
+    CreateFileW, ReadDirectoryChangesW, FILE_FLAG_BACKUP_SEMANTICS, FILE_LIST_DIRECTORY,
+    FILE_NOTIFY_CHANGE_LAST_WRITE, FILE_NOTIFY_INFORMATION, FILE_SHARE_DELETE, FILE_SHARE_READ,
+    FILE_SHARE_WRITE, OPEN_EXISTING,
+};
+use windows::Win32::System::IO::CancelIoEx;
+
+thread_local! {
+    static CONFIG_DIR_HANDLE: Cell<Option<isize>> = Cell::new(None);
+}
 
 pub static CONFIG: LazyLock<RwLock<Config>> = LazyLock::new(|| {
     RwLock::new(match Config::create_config() {
@@ -21,6 +36,7 @@ pub static CONFIG: LazyLock<RwLock<Config>> = LazyLock::new(|| {
         }
     })
 });
+
 const DEFAULT_CONFIG: &str = include_str!("resources/config.yaml");
 
 #[derive(Debug, Default, Deserialize)]
@@ -158,5 +174,112 @@ impl Config {
             }
         };
         *CONFIG.write().unwrap() = new_config;
+    }
+
+    pub fn spawn_config_listener() -> anyhow::Result<()> {
+        let config_dir: Vec<u16> = Self::get_config_dir()?
+            .into_os_string()
+            .encode_wide()
+            .chain(iter::once(0))
+            .collect();
+
+        let dir_handle = unsafe {
+            CreateFileW(
+                PCWSTR(config_dir.as_ptr()),
+                FILE_LIST_DIRECTORY.0,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                None,
+                OPEN_EXISTING,
+                FILE_FLAG_BACKUP_SEMANTICS,
+                HANDLE::default(),
+            )
+            .context("could not create dir handle for config monitoring")?
+        };
+
+        // Convert HANDLE to isize so we can pass it into the thread
+        let dir_handle_isize = dir_handle.0 as isize;
+        CONFIG_DIR_HANDLE.replace(Some(dir_handle_isize));
+
+        let _ = thread::spawn(move || unsafe {
+            // Reconvert isize back to HANDLE
+            let dir_handle = HANDLE(dir_handle_isize as _);
+
+            let mut buffer = [0u8; 256];
+            let mut bytes_returned = 0u32;
+
+            let mut now = time::Instant::now();
+            let delay = time::Duration::from_secs(1);
+
+            loop {
+                if let Err(e) = ReadDirectoryChangesW(
+                    dir_handle,
+                    buffer.as_mut_ptr() as _,
+                    buffer.len() as u32,
+                    FALSE,
+                    FILE_NOTIFY_CHANGE_LAST_WRITE,
+                    Some(ptr::addr_of_mut!(bytes_returned)),
+                    None,
+                    None,
+                ) {
+                    error!("could not check for changes in config dir: {e}");
+                    return;
+                }
+
+                // Prevent too many directory checks in quick succession
+                if now.elapsed() < delay {
+                    thread::sleep(delay - now.elapsed());
+                }
+
+                Self::process_dir_change_notifs(&buffer, bytes_returned);
+                now = time::Instant::now();
+            }
+        });
+
+        Ok(())
+    }
+
+    fn process_dir_change_notifs(buffer: &[u8; 256], bytes_returned: u32) {
+        let mut offset = 0usize;
+
+        while offset < bytes_returned as usize {
+            let info = unsafe { &*(buffer.as_ptr().add(offset) as *const FILE_NOTIFY_INFORMATION) };
+
+            // We divide FileNameLength by 2 because it's in bytes (u8), but FileName is the start of a u16 slice
+            let name_slice = unsafe {
+                slice::from_raw_parts(info.FileName.as_ptr(), info.FileNameLength as usize / 2)
+            };
+            let file_name = String::from_utf16_lossy(name_slice);
+            debug!("file changed: {}", file_name);
+
+            if file_name == "config.yaml" {
+                Config::reload_config();
+                reload_borders();
+
+                // Break to prevent multiple reloads from the same notification
+                break;
+            }
+
+            // If NextEntryOffset = 0, then we have reached the end of the notification
+            if info.NextEntryOffset == 0 {
+                break;
+            } else {
+                offset += info.NextEntryOffset as usize
+            }
+        }
+    }
+
+    pub fn destroy_config_listener() -> anyhow::Result<()> {
+        if let Some(dir_handle_isize) = CONFIG_DIR_HANDLE.get() {
+            let dir_handle = HANDLE(dir_handle_isize as _);
+
+            // Cancel all pending I/O operations on the handle
+            unsafe { CancelIoEx(dir_handle, None) }.log_if_err();
+
+            // Close the handle for cleanup
+            return unsafe { CloseHandle(dir_handle) }.map_err(anyhow::Error::new);
+        }
+
+        info!("config_dir_handle not found; skipping cleanup");
+        Ok(())
     }
 }

--- a/src/border_config.rs
+++ b/src/border_config.rs
@@ -262,7 +262,7 @@ impl ConfigWatcher {
     }
 
     pub fn start(&mut self) -> anyhow::Result<()> {
-        info!("starting config watcher");
+        debug!("starting config watcher");
 
         if self.is_running() {
             return Err(anyhow!("config watcher is already running"));
@@ -379,7 +379,7 @@ impl ConfigWatcher {
     }
 
     pub fn stop(&mut self) -> anyhow::Result<()> {
-        info!("stopping config watcher");
+        debug!("stopping config watcher");
 
         if let Some(dir_handle_isize) = self.config_dir_handle {
             let dir_handle = HANDLE(dir_handle_isize as _);

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -23,7 +23,7 @@ pub enum ColorConfig {
 
 impl Default for ColorConfig {
     fn default() -> Self {
-        Self::SolidConfig("#000000".to_string())
+        Self::SolidConfig("accent".to_string())
     }
 }
 

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -14,7 +14,7 @@ use windows::Win32::Graphics::Dwm::DwmGetColorizationColor;
 
 use crate::LogIfErr;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum ColorConfig {
     SolidConfig(String),
@@ -27,25 +27,53 @@ impl Default for ColorConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct GradientConfig {
     pub colors: Vec<String>,
     pub direction: GradientDirection,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum GradientDirection {
     Angle(String),
     Coordinates(GradientCoordinates),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct GradientCoordinates {
     pub start: [f32; 2],
     pub end: [f32; 2],
+}
+
+#[derive(Debug, Clone)]
+pub enum Color {
+    Solid(Solid),
+    Gradient(Gradient),
+}
+
+impl Default for Color {
+    fn default() -> Self {
+        Color::Solid(Solid {
+            color: D2D1_COLOR_F::default(),
+            brush: None,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Solid {
+    color: D2D1_COLOR_F,
+    brush: Option<ID2D1SolidColorBrush>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Gradient {
+    gradient_stops: Vec<D2D1_GRADIENT_STOP>, // Array of gradient stops
+    direction: GradientCoordinates,
+    brush: Option<ID2D1LinearGradientBrush>,
 }
 
 impl ColorConfig {
@@ -183,50 +211,6 @@ impl Line {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum Color {
-    Solid(Solid),
-    Gradient(Gradient),
-}
-
-#[derive(Debug, Clone)]
-pub struct Solid {
-    color: D2D1_COLOR_F,
-    brush: Option<ID2D1SolidColorBrush>,
-}
-
-#[derive(Debug, Clone)]
-pub struct Gradient {
-    gradient_stops: Vec<D2D1_GRADIENT_STOP>, // Array of gradient stops
-    direction: GradientCoordinates,
-    brush: Option<ID2D1LinearGradientBrush>,
-}
-
-impl Gradient {
-    pub fn update_start_end_points(&self, window_rect: &RECT) {
-        let width = (window_rect.right - window_rect.left) as f32;
-        let height = (window_rect.bottom - window_rect.top) as f32;
-
-        // The direction/GradientCoordinates only range from 0.0 to 1.0, but we need to
-        // convert it into coordinates in terms of pixels
-        let start_point = D2D_POINT_2F {
-            x: self.direction.start[0] * width,
-            y: self.direction.start[1] * height,
-        };
-        let end_point = D2D_POINT_2F {
-            x: self.direction.end[0] * width,
-            y: self.direction.end[1] * height,
-        };
-
-        if let Some(ref id2d1_brush) = self.brush {
-            unsafe {
-                id2d1_brush.SetStartPoint(start_point);
-                id2d1_brush.SetEndPoint(end_point)
-            };
-        }
-    }
-}
-
 impl Color {
     pub fn init_brush(
         &mut self,
@@ -339,12 +323,28 @@ impl Color {
     }
 }
 
-impl Default for Color {
-    fn default() -> Self {
-        Color::Solid(Solid {
-            color: D2D1_COLOR_F::default(),
-            brush: None,
-        })
+impl Gradient {
+    pub fn update_start_end_points(&self, window_rect: &RECT) {
+        let width = (window_rect.right - window_rect.left) as f32;
+        let height = (window_rect.bottom - window_rect.top) as f32;
+
+        // The direction/GradientCoordinates only range from 0.0 to 1.0, but we need to
+        // convert it into coordinates in terms of pixels
+        let start_point = D2D_POINT_2F {
+            x: self.direction.start[0] * width,
+            y: self.direction.start[1] * height,
+        };
+        let end_point = D2D_POINT_2F {
+            x: self.direction.end[0] * width,
+            y: self.direction.end[1] * height,
+        };
+
+        if let Some(ref id2d1_brush) = self.brush {
+            unsafe {
+                id2d1_brush.SetStartPoint(start_point);
+                id2d1_brush.SetEndPoint(end_point)
+            };
+        }
     }
 }
 

--- a/src/event_hook.rs
+++ b/src/event_hook.rs
@@ -17,7 +17,7 @@ use crate::utils::{
 use crate::window_border::ACTIVE_WINDOW;
 use crate::BORDERS;
 
-pub extern "system" fn handle_win_event(
+pub extern "system" fn process_win_event(
     _h_win_event_hook: HWINEVENTHOOK,
     _event: u32,
     _hwnd: HWND,

--- a/src/event_hook.rs
+++ b/src/event_hook.rs
@@ -2,15 +2,15 @@ use anyhow::Context;
 use windows::Win32::Foundation::{HWND, LPARAM, WPARAM};
 use windows::Win32::UI::Accessibility::HWINEVENTHOOK;
 use windows::Win32::UI::WindowsAndMessaging::{
-    CHILDID_SELF, EVENT_OBJECT_CLOAKED, EVENT_OBJECT_DESTROY, EVENT_OBJECT_FOCUS,
-    EVENT_OBJECT_HIDE, EVENT_OBJECT_LOCATIONCHANGE, EVENT_OBJECT_REORDER, EVENT_OBJECT_SHOW,
-    EVENT_OBJECT_UNCLOAKED, EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_MINIMIZEEND,
-    EVENT_SYSTEM_MINIMIZESTART, OBJID_CURSOR, OBJID_WINDOW, WS_EX_NOACTIVATE,
+    CHILDID_SELF, EVENT_OBJECT_CLOAKED, EVENT_OBJECT_DESTROY, EVENT_OBJECT_HIDE,
+    EVENT_OBJECT_LOCATIONCHANGE, EVENT_OBJECT_REORDER, EVENT_OBJECT_SHOW, EVENT_OBJECT_UNCLOAKED,
+    EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_MINIMIZEEND, EVENT_SYSTEM_MINIMIZESTART, OBJID_CURSOR,
+    OBJID_WINDOW,
 };
 
 use crate::utils::{
-    destroy_border_for_window, get_border_for_window, get_window_ex_style, hide_border_for_window,
-    is_window_top_level, is_window_visible, post_message_w, send_notify_message_w,
+    destroy_border_for_window, get_border_for_window, get_foreground_window,
+    hide_border_for_window, is_window_visible, post_message_w, send_notify_message_w,
     show_border_for_window, LogIfErr, WM_APP_FOREGROUND, WM_APP_LOCATIONCHANGE, WM_APP_MINIMIZEEND,
     WM_APP_MINIMIZESTART, WM_APP_REORDER,
 };
@@ -54,30 +54,33 @@ pub extern "system" fn handle_win_event(
                 }
             }
         }
-        // I *would* just use GetForegroundWindow(), but that sometimes doesn't work correctly due
-        // to timing issues between the event trigger and said function's processing.
-        EVENT_SYSTEM_FOREGROUND | EVENT_OBJECT_FOCUS => {
-            // We have to check WS_EX_NOACTIVATE cuz of bad Windows API
-            if !is_window_top_level(_hwnd) || get_window_ex_style(_hwnd).contains(WS_EX_NOACTIVATE)
-            {
-                return;
-            }
+        // Neither the HWND passed by the event nor the one returned by GetForegroundWindow() work
+        // correctly 100% of the time, so we use the following logic to improve reliability.
+        EVENT_SYSTEM_FOREGROUND => {
+            // Step one: check the visibility of the HWND passed by the event
+            // NOTE: just because _hwnd isn't visible doesn't necessarily mean it's incorrect, but
+            // it does at least allow us to filter through potentially incorrect HWNDs
+            let new_active_window = match is_window_visible(_hwnd) {
+                true => _hwnd.0 as isize,
+                false => {
+                    let foreground_hwnd = get_foreground_window();
 
-            let hwnd_isize = _hwnd.0 as isize;
+                    // Step two: check the validity of the HWND returned by GetForegroundWindow()
+                    match !foreground_hwnd.is_invalid() {
+                        true => foreground_hwnd.0 as isize,
+                        false => _hwnd.0 as isize,
+                    }
+                }
+            };
 
-            // Filter through repeated events
-            if hwnd_isize == *ACTIVE_WINDOW.lock().unwrap() {
-                return;
-            }
-
-            *ACTIVE_WINDOW.lock().unwrap() = hwnd_isize;
+            *ACTIVE_WINDOW.lock().unwrap() = new_active_window;
 
             // Send foreground messages to all the border windows
             for (key, val) in BORDERS.lock().unwrap().iter() {
                 let border_window = HWND(*val as _);
-                // Some apps like Flow Launcher can become focused even if they aren't visible yet,
-                // so I also need to check if 'key' is equal to '_hwnd' (the foreground window)
-                if is_window_visible(border_window) || key == &hwnd_isize {
+                // NOTE: some apps can become foreground even if they're not visible, so we also
+                // have to check the keys against the active_window HWND from earlier
+                if is_window_visible(border_window) || *key == new_active_window {
                     post_message_w(border_window, WM_APP_FOREGROUND, WPARAM(0), LPARAM(0))
                         .context("EVENT_OBJECT_FOCUS")
                         .log_if_err();

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,8 @@ fn main() {
         println!("[ERROR] {}", e);
     };
 
+    info!("starting tacky-borders");
+
     // xFFFFFFFF can be used to disable IME windows for all threads in the current process.
     if !imm_disable_ime(0xFFFFFFFF).as_bool() {
         error!("could not disable ime!");
@@ -90,7 +92,8 @@ fn main() {
             DispatchMessageW(&message);
         }
     }
-    error!("exited messsage loop in main.rs; this should not happen");
+
+    info!("exiting tacky-borders");
 }
 
 fn create_logger() -> anyhow::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,9 @@ fn main() {
     register_window_class().log_if_err();
     enum_windows().log_if_err();
 
+    // EXPERIMENTAL: Monitor config changes
+    border_config::Config::spawn_config_listener().log_if_err();
+
     unsafe {
         debug!("entering message loop!");
         let mut message = MSG::default();
@@ -149,7 +152,7 @@ fn set_event_hook() -> HWINEVENTHOOK {
             EVENT_MIN,
             EVENT_MAX,
             None,
-            Some(event_hook::handle_win_event),
+            Some(event_hook::process_win_event),
             0,
             0,
             WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS,

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,10 +83,6 @@ fn main() {
     register_window_class().log_if_err();
     enum_windows().log_if_err();
 
-    // EXPERIMENTAL: listen for config changes
-    border_config::Config::spawn_config_listener().log_if_err();
-
-    debug!("entering message loop!");
     unsafe {
         let mut message = MSG::default();
         while GetMessageW(&mut message, HWND::default(), 0, 0).into() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ mod sys_tray_icon;
 mod utils;
 mod window_border;
 
+use crate::border_config::EnableMode;
 use crate::utils::{
     create_border_for_window, get_window_rule, has_filtered_style, imm_disable_ime,
     is_window_cloaked, is_window_top_level, is_window_visible, post_message_w,
@@ -197,9 +198,11 @@ unsafe extern "system" fn enum_windows_callback(_hwnd: HWND, _lparam: LPARAM) ->
         if is_window_visible(_hwnd) && !is_window_cloaked(_hwnd) {
             let window_rule = get_window_rule(_hwnd);
 
-            if window_rule.enabled == Some(false) {
+            if window_rule.enabled == Some(EnableMode::Bool(false)) {
                 info!("border is disabled for {_hwnd:?}");
-            } else if window_rule.enabled == Some(true) || !has_filtered_style(_hwnd) {
+            } else if window_rule.enabled == Some(EnableMode::Bool(true))
+                || !has_filtered_style(_hwnd)
+            {
                 create_border_for_window(_hwnd, window_rule);
             }
         }

--- a/src/resources/config.yaml
+++ b/src/resources/config.yaml
@@ -83,9 +83,25 @@ global:
   #
   #   Note: spiral animations can be taxing on the CPU and GPU on low-end systems.
   animations:
-    active: { ReverseSpiral, Fade: { easing: EaseInOutQuad } }
-    inactive: { Spiral, Fade: { easing: EaseInOutQuad } }
     fps: 60
+
+    active:
+      - type: ReverseSpiral
+        duration: 1800
+        easing: EaseInOutQuad
+
+      - type: Fade
+        duration: 200
+        easing: EaseInOutQuad
+
+    inactive:
+      - type: Spiral
+        duration: 1800
+        easing: EaseInOutQuad
+
+      - type: Fade
+        duration: 200
+        easing: EaseInOutQuad
 
 # Customize config options on a per-app basis.
 window_rules:

--- a/src/resources/config.yaml
+++ b/src/resources/config.yaml
@@ -1,3 +1,6 @@
+# watch_config_changes: Automatically reload borders whenever the config file is modified.
+watch_config_changes: True
+
 # Global configuration options
 global:
   # border_width: Width of the border (in pixels)

--- a/src/resources/config.yaml
+++ b/src/resources/config.yaml
@@ -1,50 +1,42 @@
-# Customize global config options
+# Global configuration options
 global:
-  # border_width: the width of the border in pixels
+  # border_width: Width of the border (in pixels)
   border_width: 3
 
-  # border_offset: how offset the border is from the edges of the window in pixels
+  # border_offset: Offset of the border from the window edges (in pixels)
+  #   - Negative values shrink the border inwards
+  #   - Positive values expand the border outwards
   border_offset: -1
 
-  # border-radius: the radius of the border's corners.
-  # Supported types:
-  #   Auto
-  #   Square
-  #   Round
-  #   RoundSmall
-  #
-  #   Or just put in any number you wish to use as the radius
+  # border-radius: Radius of the border's corners. Supported values:
+  #   - Auto: Automatically determine the radius
+  #   - Square: Sharp corners (radius = 0)
+  #   - Round: Fully rounded corners
+  #   - RoundSmall: Slightly rounded corners
+  #   - Or specify any numeric value for a custom radius
   border_radius: Auto
 
   # active_color: the color of the active window's border
   # inactive_color: the color of the inactive window's border
   #
-  # Two types of colors are supported: solid and gradient.
-  #   Gradient colors support hex codes.
-  #   Solid colors support both a hex code and "accent".
-  #
-  # SOLID EXAMPLE:
-  #   active_color: "#ffffff"
-  #
-  #   OR
-  #
-  #   active_color: "accent"
-  #
-  # GRADIENT EXAMPLE:
-  #   active_color:
-  #     colors: ["#000000", "#ffffff"]
-  #     direction: 45deg
-  #
-  #   OR
-  #
-  #   active_color:
-  #     colors: ["#000000", "#ffffff"]
-  #     direction:
-  #       start: [0.0, 1.0]
-  #       end: [1.0, 0.0]
-  #
-  #   Note: [0.0, 0.0] is the top left corner
-  #         [1.0, 1.0] is the bottom right corner
+  # Supported color types:
+  #   - Solid: Use a hex code or "accent"
+  #       Example:
+  #         active_color: "#ffffff"
+  #         OR
+  #         active_color: "accent"
+  #   - Gradient: Define colors and direction
+  #       Example:
+  #         active_color:
+  #           colors: ["#000000", "#ffffff"]
+  #           direction: 45deg
+  #         OR
+  #         active_color:
+  #           colors: ["#000000", "#ffffff"]
+  #           direction:
+  #             start: [0.0, 1.0]
+  #             end: [1.0, 0.0]
+  #       Note: [0.0, 0.0] = top-left, [1.0, 1.0] = bottom-right
   active_color:
     colors: ["#6274e7", "#8752a3"]
     direction: 45deg
@@ -55,33 +47,33 @@ global:
       start: [0.0, 1.0]
       end: [1.0, 0.0]
 
-  # intialize_delay: the time (in milliseconds) it takes for the border to show after a window is opened.
-  # unminimize_delay: the time (in milliseconds) it takes for the border to show after a window is unminimized.
+  # initialize_delay: Time (in ms) before the border appears after opening a new window
+  # unminimize_delay: Time (in ms) before the border appears after unminimizing a window
   #
-  # There is no easy way to deal with window animations (such as when a window is opened or unminimized), and these
-  # delays are here to help account for that. If you have window animations disabled, I recommend setting these to 0.
+  # These settings help accommodate window animations (e.g., open or unminimize animations).
+  # If window animations are disabled, set these to 0.
   #
-  # These can also be adjusted to account for things like fade animations, which take additional time.
+  # These can also be used to accomodate border animations (e.g., fade animations).
   initialize_delay: 200
   unminimize_delay: 150
 
-  # animations:
-  #   active: adjusts the active window's animations
-  #   inactive: adjusts the inactive window's animations
-  #   fps: adjusts the animation fps
+  # animations: Configure animation behavior for window borders
+  #   fps: Animation frame rate
+  #   active: Animations for active windows
+  #   inactive: Animations for inactive windows
   #
-  #   Currently, three types of animations are supported:
-  #     Spiral,
-  #     ReverseSpiral,
-  #     Fade,
+  # Supported animation types:
+  #   - Spiral
+  #   - ReverseSpiral
+  #   - Fade
   #
-  #   The animation types can be adjusted by specifying their name like follows:
-  #     active: { Spiral, Fade }
+  # Specify animation types and parameters as follows:
+  #   active:
+  #     - type: Spiral
+  #       duration: 1800
+  #       easing: Linear
   #
-  #   The animation parameters can be adjusted by appending them to the animation type like follows:
-  #     active: { Spiral: { duration: 1800, easing: Linear }, Fade: { duration: 300, easing: EaseInOutQuad } }
-  #
-  #   Note: spiral animations can be taxing on the CPU and GPU on low-end systems.
+  # Note: Spiral animations may be resource-intensive on low-end systems.
   animations:
     fps: 60
 
@@ -103,38 +95,39 @@ global:
         duration: 200
         easing: EaseInOutQuad
 
-# Customize config options on a per-app basis.
+# Per-application configuration overrides
 window_rules:
-  - match: "Class"
+  - match: Class
     name: "Windows.UI.Core.CoreWindow"
-    enabled: false
+    enabled: False
 
-  - match: "Class"
+  - match: Class
     name: "XamlExplorerHostIslandWindow"
-    enabled: false
+    enabled: False
 
-  - match: "Title"
-    strategy: "Contains"
+  - match: Title
+    strategy: Contains
     name: "Zebar"
-    enabled: false
+    enabled: False
 
-  - match: "Title"
+  - match: Title
     name: "komorebi-bar"
-    enabled: false
+    enabled: False
 
-  - match: "Title"
+  - match: Title
     name: "keyviz"
-    enabled: false
+    enabled: False
 
-  - match: "Title"
+  - match: Title
     name: "Picture-in-Picture"
-    enabled: false
+    enabled: False
 
-  # EXAMPLE CONFIGURATION:
-  # - match: "Class"               # Currently supports "Class" or "Title"
-  #   name: "MozillaWindowClass"   # Name of the class or title
-  #   strategy: "Equals"           # Optional. Currently supports "Equals", "Contains", or "Regex". Defaults to "Equals"
-  #   enabled: true                # Optional. Enables/disables the border. Defaults to true. Note: you can't forcibly enable borders
+  # Example rule:
+  # - match: Class                   # Match based on Class or Title
+  #   name: "MozillaWindowClass"     # Class or title name to match
+  #   strategy: Equals               # Matching strategy: Equals, Contains, or Regex (default: Equals)
+  #   enabled: True                  # Enable mode: True, False, or Auto (default: Auto)
   #
-  # Any option in the global config can also be defined in window_rules.
-  # If something isn't defined here, it will default to global config options.
+  # Notes:
+  #   - Any option in the global config can also be defined in window_rules.
+  #   - If not defined in a rule, settings will fall back to global config values.

--- a/src/sys_tray_icon.rs
+++ b/src/sys_tray_icon.rs
@@ -4,7 +4,7 @@ use tray_icon::{Icon, TrayIcon, TrayIconBuilder};
 use windows::Win32::System::Threading::ExitProcess;
 use windows::Win32::UI::Accessibility::UnhookWinEvent;
 
-use crate::border_config::Config;
+use crate::border_config::{Config, CONFIG_WATCHER};
 use crate::{reload_borders, EVENT_HOOK};
 
 pub fn create_tray_icon() -> anyhow::Result<TrayIcon> {
@@ -57,7 +57,7 @@ pub fn create_tray_icon() -> anyhow::Result<TrayIcon> {
         // Close
         "2" => unsafe {
             let unhook_bool = UnhookWinEvent(EVENT_HOOK.get());
-            let destroy_res = Config::destroy_config_watcher();
+            let destroy_res = CONFIG_WATCHER.lock().unwrap().stop();
 
             if unhook_bool.as_bool() && destroy_res.is_ok() {
                 debug!("exiting tacky-borders!");

--- a/src/sys_tray_icon.rs
+++ b/src/sys_tray_icon.rs
@@ -56,13 +56,14 @@ pub fn create_tray_icon() -> anyhow::Result<TrayIcon> {
         }
         // Close
         "2" => unsafe {
-            if UnhookWinEvent(EVENT_HOOK.get()).as_bool()
-                && Config::destroy_config_listener().is_ok()
-            {
+            let unhook_bool = UnhookWinEvent(EVENT_HOOK.get());
+            let destroy_res = Config::destroy_config_watcher();
+
+            if unhook_bool.as_bool() && destroy_res.is_ok() {
                 debug!("exiting tacky-borders!");
                 ExitProcess(0);
             } else {
-                error!("could not unhook win event hook or destroy config monitor");
+                error!("attempt to unhook win event: {unhook_bool:?}; attempt to destroy config watcher: {destroy_res:?}");
             }
         },
         _ => {}

--- a/src/sys_tray_icon.rs
+++ b/src/sys_tray_icon.rs
@@ -56,11 +56,13 @@ pub fn create_tray_icon() -> anyhow::Result<TrayIcon> {
         }
         // Close
         "2" => unsafe {
-            if UnhookWinEvent(EVENT_HOOK.get()).as_bool() {
+            if UnhookWinEvent(EVENT_HOOK.get()).as_bool()
+                && Config::destroy_config_listener().is_ok()
+            {
                 debug!("exiting tacky-borders!");
                 ExitProcess(0);
             } else {
-                error!("could not unhook win event hook");
+                error!("could not unhook win event hook or destroy config monitor");
             }
         },
         _ => {}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,10 +9,10 @@ use windows::Win32::Graphics::Dwm::{
 use windows::Win32::UI::HiDpi::{SetProcessDpiAwarenessContext, DPI_AWARENESS_CONTEXT};
 use windows::Win32::UI::Input::Ime::ImmDisableIME;
 use windows::Win32::UI::WindowsAndMessaging::{
-    GetForegroundWindow, GetWindowLongW, GetWindowTextW, IsWindowVisible, PostMessageW,
+    GetForegroundWindow, GetWindowLongW, GetWindowTextW, IsIconic, IsWindowVisible, PostMessageW,
     RealGetWindowClassW, SendNotifyMessageW, GWL_EXSTYLE, GWL_STYLE, WINDOW_EX_STYLE, WINDOW_STYLE,
     WM_APP, WM_NCDESTROY, WS_CHILD, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_WINDOWEDGE,
-    WS_MAXIMIZE, WS_MINIMIZE,
+    WS_MAXIMIZE,
 };
 
 use anyhow::{anyhow, Context};
@@ -215,9 +215,7 @@ pub fn get_foreground_window() -> HWND {
 }
 
 pub fn is_window_minimized(hwnd: HWND) -> bool {
-    let style = get_window_style(hwnd);
-
-    style.contains(WS_MINIMIZE)
+    unsafe { IsIconic(hwnd).as_bool() }
 }
 
 pub fn post_message_w(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,6 +17,9 @@ use windows::Win32::UI::WindowsAndMessaging::{
 
 use anyhow::{anyhow, Context};
 use regex::Regex;
+use std::fs;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::path::Path;
 use std::ptr;
 use std::thread;
 
@@ -367,6 +370,15 @@ pub fn hide_border_for_window(hwnd: HWND) {
                 .log_if_err();
         }
     });
+}
+
+pub fn get_file_hash(file_path: &Path) -> anyhow::Result<u64> {
+    let mut hasher = DefaultHasher::new();
+
+    let file = fs::read(file_path)?;
+    file.hash(&mut hasher);
+
+    Ok(hasher.finish())
 }
 
 // Bezier curve algorithm together with @0xJWLabs

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -40,9 +40,6 @@ pub trait LogIfErr {
 impl LogIfErr for anyhow::Result<()> {
     fn log_if_err(&self) {
         if let Err(e) = self {
-            // TODO for some reason if I use {:#} or {:?}, some errors will repeatedly print (like
-            // the one in main.rs for tray_icon_result). It could have something to do with how they
-            // implement .source()
             error!("{e:#}");
         }
     }
@@ -51,9 +48,6 @@ impl LogIfErr for anyhow::Result<()> {
 impl LogIfErr for windows::core::Result<()> {
     fn log_if_err(&self) {
         if let Err(e) = self {
-            // TODO for some reason if I use {:#} or {:?}, some errors will repeatedly print (like
-            // the one in main.rs for tray_icon_result). It could have something to do with how they
-            // implement .source()
             error!("{e:#}");
         }
     }

--- a/src/window_border.rs
+++ b/src/window_border.rs
@@ -1,4 +1,4 @@
-use crate::animations::{self, AnimType, Animations};
+use crate::animations::{self, AnimType, AnimVec, Animations};
 use crate::border_config::{WindowRule, CONFIG};
 use crate::colors::Color;
 use crate::utils::{
@@ -350,10 +350,7 @@ impl WindowBorder {
     fn update_color(&mut self, check_delay: Option<u64>) -> anyhow::Result<()> {
         self.is_active_window = self.tracking_window.0 as isize == *ACTIVE_WINDOW.lock().unwrap();
 
-        match animations::get_current_anims(self)
-            .iter()
-            .any(|anim_params| anim_params.anim_type == AnimType::Fade)
-        {
+        match animations::get_current_anims(self).contains_type(AnimType::Fade) {
             false => self.update_brush_opacities(),
             true if check_delay == Some(0) => {
                 self.update_brush_opacities();

--- a/src/window_border.rs
+++ b/src/window_border.rs
@@ -1,4 +1,4 @@
-use crate::animations::{self, AnimType, AnimVec, Animations, AnimationsConfig};
+use crate::animations::{self, AnimType, AnimVec, Animations};
 use crate::border_config::{WindowRule, CONFIG};
 use crate::colors::Color;
 use crate::utils::{
@@ -196,15 +196,11 @@ impl WindowBorder {
             .inactive_color
             .as_ref()
             .unwrap_or(&global.inactive_color);
-
-        // TODO: what the hell
-        let binding = AnimationsConfig::default();
         let animations_config = window_rule
             .animations
             .as_ref()
-            .unwrap_or(&global.animations.as_ref().unwrap_or(&binding));
+            .unwrap_or(&global.animations);
 
-        // Convert ColorConfig structs to Color
         self.active_color = active_color_config.to_color(true);
         self.inactive_color = inactive_color_config.to_color(false);
 
@@ -229,11 +225,11 @@ impl WindowBorder {
             true => 0,
             false => window_rule
                 .initialize_delay
-                .unwrap_or(global.initialize_delay.unwrap_or(250)),
+                .unwrap_or(global.initialize_delay),
         };
         self.unminimize_delay = window_rule
             .unminimize_delay
-            .unwrap_or(global.unminimize_delay.unwrap_or(200));
+            .unwrap_or(global.unminimize_delay);
 
         drop(config);
         drop(window_rule);

--- a/src/window_border.rs
+++ b/src/window_border.rs
@@ -350,7 +350,10 @@ impl WindowBorder {
     fn update_color(&mut self, check_delay: Option<u64>) -> anyhow::Result<()> {
         self.is_active_window = self.tracking_window.0 as isize == *ACTIVE_WINDOW.lock().unwrap();
 
-        match animations::get_current_anims(self).contains_key(&AnimType::Fade) {
+        match animations::get_current_anims(self)
+            .iter()
+            .any(|anim_params| anim_params.anim_type == AnimType::Fade)
+        {
             false => self.update_brush_opacities(),
             true if check_delay == Some(0) => {
                 self.update_brush_opacities();
@@ -635,8 +638,8 @@ impl WindowBorder {
 
                 let mut update = false;
 
-                for (anim_type, anim_params) in animations::get_current_anims(self).clone().iter() {
-                    match anim_type {
+                for anim_params in animations::get_current_anims(self).clone().iter() {
+                    match anim_params.anim_type {
                         AnimType::Spiral => {
                             animations::animate_spiral(self, &anim_elapsed, anim_params, false);
                             update = true;

--- a/src/window_border.rs
+++ b/src/window_border.rs
@@ -48,14 +48,10 @@ use windows::Win32::UI::WindowsAndMessaging::{
 
 static RENDER_FACTORY: LazyLock<ID2D1Factory> = unsafe {
     LazyLock::new(|| {
-        match D2D1CreateFactory::<ID2D1Factory>(D2D1_FACTORY_TYPE_MULTI_THREADED, None) {
-            Ok(factory) => factory,
-            Err(e) => {
-                // Not sure how I can recover from this error so I'm just going to panic
-                error!("could not create ID2D1Factory: {e}");
-                panic!("could not create ID2D1Factory: {e}");
-            }
-        }
+        D2D1CreateFactory(D2D1_FACTORY_TYPE_MULTI_THREADED, None).unwrap_or_else(|error| {
+            error!("could not create ID2D1Factory: {error}");
+            panic!()
+        })
     })
 };
 
@@ -181,7 +177,6 @@ impl WindowBorder {
         let config = CONFIG.read().unwrap();
         let global = &config.global;
 
-        // TODO make this code prettier somehow
         let width_config = window_rule.border_width.unwrap_or(global.border_width);
         let offset_config = window_rule.border_offset.unwrap_or(global.border_offset);
         let radius_config = window_rule

--- a/src/window_border.rs
+++ b/src/window_border.rs
@@ -1,4 +1,4 @@
-use crate::animations::{self, AnimType, AnimVec, Animations};
+use crate::animations::{self, AnimType, AnimVec, Animations, AnimationsConfig};
 use crate::border_config::{WindowRule, CONFIG};
 use crate::colors::Color;
 use crate::utils::{
@@ -197,6 +197,13 @@ impl WindowBorder {
             .as_ref()
             .unwrap_or(&global.inactive_color);
 
+        // TODO: what the hell
+        let binding = AnimationsConfig::default();
+        let animations_config = window_rule
+            .animations
+            .as_ref()
+            .unwrap_or(&global.animations.as_ref().unwrap_or(&binding));
+
         // Convert ColorConfig structs to Color
         self.active_color = active_color_config.to_color(true);
         self.inactive_color = inactive_color_config.to_color(false);
@@ -210,10 +217,7 @@ impl WindowBorder {
         self.border_offset = offset_config;
         self.border_radius = radius_config.to_radius(self.border_width, dpi, self.tracking_window);
 
-        self.animations = window_rule
-            .animations
-            .clone()
-            .unwrap_or(global.animations.clone().unwrap_or_default());
+        self.animations = animations_config.to_animations();
 
         // If the tracking window is part of the initial windows list (meaning it was already open when
         // tacky-borders was launched), then there should be no initialize delay.

--- a/src/window_border.rs
+++ b/src/window_border.rs
@@ -48,8 +48,8 @@ use windows::Win32::UI::WindowsAndMessaging::{
 
 static RENDER_FACTORY: LazyLock<ID2D1Factory> = unsafe {
     LazyLock::new(|| {
-        D2D1CreateFactory(D2D1_FACTORY_TYPE_MULTI_THREADED, None).unwrap_or_else(|error| {
-            error!("could not create ID2D1Factory: {error}");
+        D2D1CreateFactory(D2D1_FACTORY_TYPE_MULTI_THREADED, None).unwrap_or_else(|err| {
+            error!("could not create ID2D1Factory: {err}");
             panic!()
         })
     })


### PR DESCRIPTION
BREAKING CHANGE: The animations section in the config.yaml must be updated

The config for animations has been replaced with a Vec-based format. This was done to improve consistency with the rest of the config and hopefully make it easier to understand.