### PR TITLE
feat: Add hexa() color format with alpha transparency

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,16 @@ global:
   # inactive_color: the color of the inactive window's border
   #
   # Supported color types:
-  #   - Solid: Use a hex code or "accent"
+  #   - Solid: Use a hex code, "accent", or hexa() format
   #       Example:
   #         active_color: "#ffffff"
   #         OR
   #         active_color: "accent"
+  #         OR
+  #         active_color: "hexa(accent,40%)"  # Windows accent color with 40% opacity
+  #         OR
+  #         active_color: "hexa(#ff0000,60%)" # Red color with 60% opacity
+  #       NOTE: Instead of using hex with alpha like "#cff70f3D", you can use "hexa(#cff70f,24%)"
   #   - Gradient: Define colors and direction
   #       Example:
   #         active_color:

--- a/src/resources/config.yaml
+++ b/src/resources/config.yaml
@@ -62,11 +62,16 @@ global:
   # inactive_color: the color of the inactive window's border
   #
   # Supported color types:
-  #   - Solid: Use a hex code or "accent"
+  #   - Solid: Use a hex code, "accent", or hexa() format
   #       Example:
   #         active_color: "#ffffff"
   #         OR
   #         active_color: "accent"
+  #         OR
+  #         active_color: "hexa(accent,40%)"
+  #         OR
+  #         active_color: "hexa(#ff0000,60%)"
+  #       NOTE: Instead of using hex with alpha like "#cff70f3D", you can use "hexa(#cff70f,24%)"
   #   - Gradient: Define colors and direction
   #       Example:
   #         active_color:


### PR DESCRIPTION
## Summary
This PR adds support for a new `hexa()` color format that allows specifying colors with alpha transparency using a more readable percentage-based syntax.

## Changes
- **New feature**: `hexa(color,X%)` format support
  - `color` can be `accent` (Windows accent color) or hex code
  - `X%` specifies opacity percentage (0-100%)
- **Implementation**: Added `parse_hexa()` function in `src/colors.rs`
- **Documentation**: Updated README.md and config.yaml with examples
- **Tests**: Added comprehensive test coverage for all hexa format variations

## Examples
```yaml
active_color: "hexa(accent,40%)"    # Windows accent with 40% opacity
active_color: "hexa(#ff0000,60%)"   # Red with 60% opacity
active_color: "hexa(00ff00,50%)"    # Green with 50% opacity (# optional)
```

## Benefits
- More intuitive than hex alpha values (e.g., hexa(#ff0000,60%) vs #ff000099)
- Supports both accent colors and custom hex codes
- Alpha override functionality for existing hex codes with alpha