### PR TITLE
fix: Prevent borders from appearing on all virtual desktops

### DIFF
--- a/src/window_border.rs
+++ b/src/window_border.rs
@@ -132,7 +132,7 @@ impl WindowBorder {
                 CW_USEDEFAULT,
                 CW_USEDEFAULT,
                 CW_USEDEFAULT,
-                None,
+                Some(self.tracking_window),
                 None,
                 None,
                 Some(ptr::addr_of!(*self) as _),


### PR DESCRIPTION
### Bug Fix: Incorrect Border Drawing on Virtual Desktops

####  The Issue

When the cursor is hovered over the Windows Virtual Desktop button (Task View button), the border window was incorrectly being drawn across **all virtual desktops**, instead of being constrained to the current desktop.

This resulted in visible, spurious borders appearing even when switching away to another virtual desktop, creating a visual distraction.

#### The Root Cause

The `border_window` was created with its parent window argument set to `None`:

```rust
// ...
// Before fix:
self.border_window.0 = CreateWindowExW(
    WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_TRANSPARENT,
    w!("border"),
    PCWSTR(title.as_ptr()),
    WS_POPUP | WS_DISABLED,
    CW_USEDEFAULT,
    CW_USEDEFAULT,
    CW_USEDEFAULT,
    CW_USEDEFAULT,
    None,
    None,
    None,
    Some(ptr::addr_of!(*self) as _),
)?;
// ...
```

By setting the parent to `None`, the operating system treats the border window as a top-level, unowned window, causing it to appear on all virtual desktops globally, irrespective of the current desktop context.

#### The Solution

This commit sets the parent of the `border_window` to be the `tracking_window`:

```rust
// ...
self.border_window.0 = CreateWindowExW(
    WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_TRANSPARENT,
    w!("border"),
    PCWSTR(title.as_ptr()),
    WS_POPUP | WS_DISABLED,
    CW_USEDEFAULT,
    CW_USEDEFAULT,
    CW_USEDEFAULT,
    CW_USEDEFAULT,
    Some(self.tracking_window),
    None,
    None,
    Some(ptr::addr_of!(*self) as _),
)?;
// ...
```

By explicitly setting the parent, we ensure that the border window's visibility and lifetime are tied to the parent's context (`self.tracking_window`), which is correctly scoped to the active virtual desktop, thereby preventing the border from appearing globally.


