### PR TITLE
fix: improve z-order handling for BelowWindow mode and prevent ghost borders

### DIFF
--- a/src/event_hook.rs
+++ b/src/event_hook.rs
@@ -4,8 +4,8 @@ use windows::Win32::UI::Accessibility::HWINEVENTHOOK;
 use windows::Win32::UI::WindowsAndMessaging::{
     CHILDID_SELF, EVENT_OBJECT_CLOAKED, EVENT_OBJECT_DESTROY, EVENT_OBJECT_HIDE,
     EVENT_OBJECT_LOCATIONCHANGE, EVENT_OBJECT_REORDER, EVENT_OBJECT_SHOW, EVENT_OBJECT_UNCLOAKED,
-    EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_MINIMIZEEND, EVENT_SYSTEM_MINIMIZESTART, OBJID_CURSOR,
-    OBJID_WINDOW,
+    EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_MINIMIZEEND, EVENT_SYSTEM_MINIMIZESTART, OBJID_CLIENT,
+    OBJID_CURSOR, OBJID_WINDOW,
 };
 
 use crate::APP_STATE;
@@ -43,6 +43,11 @@ pub extern "system" fn process_win_event(
             }
         }
         EVENT_OBJECT_REORDER => {
+            // Ignore OBJIDs not needed for window Z-order handling.
+            if _id_object != OBJID_CLIENT.0 {
+                return;
+            }
+
             // Send reorder messages to all the border windows
             for value in APP_STATE.borders.lock().unwrap().values() {
                 let border_window = HWND(*value as _);

--- a/src/window_border.rs
+++ b/src/window_border.rs
@@ -83,7 +83,6 @@ pub struct WindowBorder {
     unminimize_delay: u64,
     // ------------------------------
     is_paused: bool,
-    last_reorder_time: Option<time::Instant>,
 }
 
 impl WindowBorder {
@@ -106,7 +105,6 @@ impl WindowBorder {
             initialize_delay: Default::default(),
             unminimize_delay: Default::default(),
             is_paused: Default::default(),
-            last_reorder_time: None,
         });
 
         this.create_window()
@@ -899,32 +897,26 @@ impl WindowBorder {
                     return LRESULT(0);
                 }
 
-                // Check if z-order needs fixing
-                let z_order_correct = match self.border_z_order {
-                    ZOrderMode::AboveWindow => (
-                        unsafe { GetWindow(self.tracking_window, GW_HWNDPREV) }
-                            == Ok(self.border_window.0)
-                    ),
-                    ZOrderMode::BelowWindow => (
-                        unsafe { GetWindow(self.tracking_window, GW_HWNDNEXT) }
-                            == Ok(self.border_window.0)
-                    ),
-                };
-
-                // If z-order is correct, apply debouncing to prevent excessive checks
-                // If z-order is WRONG, always fix it regardless of debounce timing
-                if z_order_correct {
-                    let now = time::Instant::now();
-                    if let Some(last_time) = self.last_reorder_time {
-                        if now.duration_since(last_time) < time::Duration::from_millis(16) {
-                            return LRESULT(0);
+                match self.border_z_order {
+                    ZOrderMode::AboveWindow => {
+                        // When the tracking window reorders its contents, it may change the z-order. So,
+                        // we first check whether the border is still above the tracking window, and if
+                        // not, we must update its position and place it back on top
+                        if unsafe { GetWindow(self.tracking_window, GW_HWNDPREV) }
+                            != Ok(self.border_window.0)
+                        {
+                            self.update_position(None).log_if_err();
                         }
                     }
-                    self.last_reorder_time = Some(now);
-                } else {
-                    // Z-order is wrong - fix it immediately
-                    self.last_reorder_time = Some(time::Instant::now());
-                    self.update_position(None).log_if_err();
+                    ZOrderMode::BelowWindow => {
+                        // Check if the border is still directly below the tracking window
+                        // GW_HWNDNEXT returns the window below the specified window in z-order
+                        if unsafe { GetWindow(self.tracking_window, GW_HWNDNEXT) }
+                            != Ok(self.border_window.0)
+                        {
+                            self.update_position(None).log_if_err();
+                        }
+                    }
                 }
             }
             // EVENT_SYSTEM_FOREGROUND

--- a/src/window_border.rs
+++ b/src/window_border.rs
@@ -19,7 +19,7 @@ use windows::Win32::Graphics::Gdi::{CreateRectRgn, HMONITOR, ValidateRect};
 use windows::Win32::UI::HiDpi::MDT_DEFAULT;
 use windows::Win32::UI::WindowsAndMessaging::{
     CREATESTRUCTW, CW_USEDEFAULT, CreateWindowExW, DBT_DEVNODES_CHANGED, DefWindowProcW,
-    GW_HWNDPREV, GWLP_USERDATA, GetSystemMetrics, GetWindow, GetWindowLongPtrW, HWND_TOP,
+    GW_HWNDNEXT, GW_HWNDPREV, GWLP_USERDATA, GetSystemMetrics, GetWindow, GetWindowLongPtrW, HWND_TOP,
     LWA_ALPHA, PBT_APMRESUMEAUTOMATIC, PBT_APMRESUMESUSPEND, PBT_APMSUSPEND, PostQuitMessage,
     SET_WINDOW_POS_FLAGS, SM_CXVIRTUALSCREEN, SWP_HIDEWINDOW, SWP_NOACTIVATE, SWP_NOREDRAW,
     SWP_NOSENDCHANGING, SWP_NOZORDER, SWP_SHOWWINDOW, SetLayeredWindowAttributes,
@@ -42,7 +42,7 @@ use crate::utils::{
     WM_APP_MINIMIZESTART, WM_APP_RECREATE_DRAWER, WM_APP_REORDER, WM_APP_SHOWUNCLOAKED,
     WindowsCompatibleError, WindowsCompatibleResult, WindowsContext, are_rects_same_size,
     get_dpi_for_monitor, get_monitor_info, get_window_rule, get_window_title, has_native_border,
-    is_window_arranged, is_window_cloaked, is_window_minimized, is_window_visible, loword,
+    is_window, is_window_arranged, is_window_cloaked, is_window_minimized, is_window_visible, loword,
     monitor_from_window, post_message_w,
 };
 
@@ -839,6 +839,12 @@ impl WindowBorder {
                     return LRESULT(0);
                 }
 
+                // Check if tracking window still exists to avoid ghost borders
+                if !is_window(Some(self.tracking_window)) {
+                    self.cleanup_and_queue_exit();
+                    return LRESULT(0);
+                }
+
                 // This is mainly here to handle cases where a window is made borderless fullscreen
                 // (if 'follow_native_border' is set to true in the config), which doesn't have any
                 // dedicated events like MINIMIZEEND. Note that we don't set 'is_paused' to true as
@@ -884,21 +890,43 @@ impl WindowBorder {
                     .set_anims_timer_if_needed(self.border_window.0);
             }
             // EVENT_OBJECT_REORDER
-            WM_APP_REORDER => match self.border_z_order {
-                ZOrderMode::AboveWindow => {
-                    // When the tracking window reorders its contents, it may change the z-order. So,
-                    // we first check whether the border is still above the tracking window, and if
-                    // not, we must update its position and place it back on top
-                    if unsafe { GetWindow(self.tracking_window, GW_HWNDPREV) }
-                        != Ok(self.border_window.0)
-                    {
-                        self.update_position(None).log_if_err();
+            WM_APP_REORDER => {
+                // First check if the tracking window still exists to avoid ghost borders
+                if !is_window(Some(self.tracking_window)) {
+                    self.cleanup_and_queue_exit();
+                    return LRESULT(0);
+                }
+
+                match self.border_z_order {
+                    ZOrderMode::AboveWindow => {
+                        // When the tracking window reorders its contents, it may change the z-order. So,
+                        // we first check whether the border is still above the tracking window, and if
+                        // not, we must update its position and place it back on top
+                        if unsafe { GetWindow(self.tracking_window, GW_HWNDPREV) }
+                            != Ok(self.border_window.0)
+                        {
+                            self.update_position(None).log_if_err();
+                        }
+                    }
+                    ZOrderMode::BelowWindow => {
+                        // Check if the border is still directly below the tracking window
+                        // GW_HWNDNEXT returns the window below the specified window in z-order
+                        if unsafe { GetWindow(self.tracking_window, GW_HWNDNEXT) }
+                            != Ok(self.border_window.0)
+                        {
+                            self.update_position(None).log_if_err();
+                        }
                     }
                 }
-                ZOrderMode::BelowWindow => {} // do nothing
-            },
+            }
             // EVENT_SYSTEM_FOREGROUND
             WM_APP_FOREGROUND => {
+                // Check if tracking window still exists to avoid ghost borders
+                if !is_window(Some(self.tracking_window)) {
+                    self.cleanup_and_queue_exit();
+                    return LRESULT(0);
+                }
+
                 self.update_color(None);
                 self.update_position(None).log_if_err();
                 self.render().log_if_err();


### PR DESCRIPTION
## Summary

This PR addresses two z-order related issues:

### 1. BelowWindow Z-Order Fix
When border_z_order is set to BelowWindow, nested window borders would incorrectly go behind background windows when focus changed.

**Fix**: Added z-order correction logic in the WM_APP_REORDER handler using GW_HWNDNEXT to detect when the border drifts out of position and reposition it correctly.

### 2. Ghost Border Prevention
Ghost borders (border outlines without window content) would linger after closing windows.

**Fix**: Added is_window() validity checks in three message handlers:
- WM_APP_LOCATIONCHANGE
- WM_APP_REORDER
- WM_APP_FOREGROUND

These checks immediately cleanup the border if the tracking window no longer exists.

## Changes
- Added GW_HWNDNEXT and is_window to imports
- Updated WM_APP_REORDER handler with z-order correction for BelowWindow mode
- Added validity checks in three handlers to prevent ghost borders

## Testing
- Build: ✅ cargo build --release passes
- Unit tests: ✅ All pass
- Manual testing: ✅ Verified with nested windows and rapid window closing