### PR TITLE
feat: add `blur` and `spread` to effects configuration

### DIFF
--- a/src/effects.rs
+++ b/src/effects.rs
@@ -5,13 +5,14 @@ use windows::Win32::Graphics::Direct2D::Common::{
     D2D1_COMPOSITE_MODE_DESTINATION_OUT, D2D1_COMPOSITE_MODE_SOURCE_OVER,
 };
 use windows::Win32::Graphics::Direct2D::{
-    CLSID_D2D1Composite, CLSID_D2D1GaussianBlur, CLSID_D2D1Opacity, CLSID_D2D1Shadow,
-    CLSID_D2D12DAffineTransform, D2D1_2DAFFINETRANSFORM_PROP_TRANSFORM_MATRIX,
-    D2D1_DIRECTIONALBLUR_OPTIMIZATION_SPEED, D2D1_GAUSSIANBLUR_PROP_OPTIMIZATION,
-    D2D1_GAUSSIANBLUR_PROP_STANDARD_DEVIATION, D2D1_INTERPOLATION_MODE_LINEAR,
-    D2D1_OPACITY_PROP_OPACITY, D2D1_PROPERTY_TYPE_ENUM, D2D1_PROPERTY_TYPE_FLOAT,
-    D2D1_PROPERTY_TYPE_MATRIX_3X2, D2D1_SHADOW_PROP_BLUR_STANDARD_DEVIATION,
-    D2D1_SHADOW_PROP_OPTIMIZATION, ID2D1CommandList, ID2D1Effect,
+    CLSID_D2D1ColorMatrix, CLSID_D2D1Composite, CLSID_D2D1GaussianBlur, CLSID_D2D1Morphology,
+    CLSID_D2D1Opacity, CLSID_D2D12DAffineTransform, D2D1_2DAFFINETRANSFORM_PROP_TRANSFORM_MATRIX,
+    D2D1_COLORMATRIX_PROP_COLOR_MATRIX, D2D1_DIRECTIONALBLUR_OPTIMIZATION_SPEED,
+    D2D1_GAUSSIANBLUR_PROP_OPTIMIZATION, D2D1_GAUSSIANBLUR_PROP_STANDARD_DEVIATION,
+    D2D1_INTERPOLATION_MODE_LINEAR, D2D1_MORPHOLOGY_MODE_DILATE, D2D1_MORPHOLOGY_PROP_HEIGHT,
+    D2D1_MORPHOLOGY_PROP_MODE, D2D1_MORPHOLOGY_PROP_WIDTH, D2D1_OPACITY_PROP_OPACITY,
+    D2D1_PROPERTY_TYPE_ENUM, D2D1_PROPERTY_TYPE_FLOAT, D2D1_PROPERTY_TYPE_MATRIX_3X2,
+    D2D1_PROPERTY_TYPE_MATRIX_5X4, D2D1_PROPERTY_TYPE_UINT32, ID2D1CommandList, ID2D1Effect,
 };
 use windows_numerics::Matrix3x2;
 
@@ -122,48 +123,179 @@ impl Effects {
                     for effect_params in effect_params_vec.iter() {
                         let effect = match effect_params.effect_type {
                             EffectType::Glow => {
+                                // Create the blur effect first
                                 let blur_effect = d2d_context
                                     .CreateEffect(&CLSID_D2D1GaussianBlur)
-                                    .windows_context("blur_effect")?;
-                                blur_effect.SetInput(0, border_bitmap, false);
+                                    .windows_context("glow_blur_effect")?;
+                                
+                                // If spread > 0, apply morphology dilation before blur
+                                // This preserves corner shapes while expanding the glow
+                                if effect_params.spread > 0.0 {
+                                    let morphology_effect = d2d_context
+                                        .CreateEffect(&CLSID_D2D1Morphology)
+                                        .windows_context("glow_morphology_effect")?;
+                                    morphology_effect.SetInput(0, border_bitmap, false);
+                                    
+                                    // Set morphology mode to dilate (expand)
+                                    morphology_effect
+                                        .SetValue(
+                                            D2D1_MORPHOLOGY_PROP_MODE.0 as u32,
+                                            D2D1_PROPERTY_TYPE_ENUM,
+                                            &D2D1_MORPHOLOGY_MODE_DILATE.0.to_le_bytes(),
+                                        )
+                                        .windows_context("glow_morphology_effect.SetValue() mode")?;
+                                    
+                                    // Set dilation size based on spread
+                                    let dilation_size = (effect_params.spread.round() as u32).max(1);
+                                    morphology_effect
+                                        .SetValue(
+                                            D2D1_MORPHOLOGY_PROP_WIDTH.0 as u32,
+                                            D2D1_PROPERTY_TYPE_UINT32,
+                                            &dilation_size.to_le_bytes(),
+                                        )
+                                        .windows_context("glow_morphology_effect.SetValue() width")?;
+                                    morphology_effect
+                                        .SetValue(
+                                            D2D1_MORPHOLOGY_PROP_HEIGHT.0 as u32,
+                                            D2D1_PROPERTY_TYPE_UINT32,
+                                            &dilation_size.to_le_bytes(),
+                                        )
+                                        .windows_context("glow_morphology_effect.SetValue() height")?;
+                                    
+                                    // Chain blur to morphology output
+                                    blur_effect.SetInput(
+                                        0,
+                                        &morphology_effect
+                                            .GetOutput()
+                                            .windows_context("could not get glow morphology output")?,
+                                        false,
+                                    );
+                                } else {
+                                    // No spread - just blur the border directly
+                                    blur_effect.SetInput(0, border_bitmap, false);
+                                }
+                                
+                                // Apply blur using config's std_dev as-is
                                 blur_effect
                                     .SetValue(
                                         D2D1_GAUSSIANBLUR_PROP_STANDARD_DEVIATION.0 as u32,
                                         D2D1_PROPERTY_TYPE_FLOAT,
                                         &effect_params.std_dev.to_le_bytes(),
                                     )
-                                    .windows_context("blur_effect.SetValue() std deviation")?;
+                                    .windows_context("glow_blur_effect.SetValue() std deviation")?;
                                 blur_effect
                                     .SetValue(
                                         D2D1_GAUSSIANBLUR_PROP_OPTIMIZATION.0 as u32,
                                         D2D1_PROPERTY_TYPE_ENUM,
                                         &D2D1_DIRECTIONALBLUR_OPTIMIZATION_SPEED.0.to_le_bytes(),
                                     )
-                                    .windows_context("blur_effect.SetValue() optimization")?;
+                                    .windows_context("glow_blur_effect.SetValue() optimization")?;
 
                                 blur_effect
                             }
                             EffectType::Shadow => {
-                                let shadow_effect = d2d_context
-                                    .CreateEffect(&CLSID_D2D1Shadow)
-                                    .windows_context("shadow_effect")?;
-                                shadow_effect.SetInput(0, border_bitmap, false);
-                                shadow_effect
+                                // Create the color matrix effect to convert to black
+                                let color_matrix_effect = d2d_context
+                                    .CreateEffect(&CLSID_D2D1ColorMatrix)
+                                    .windows_context("color_matrix_effect")?;
+                                
+                                // 5x4 matrix in row-major order: sets RGB to 0, keeps A
+                                #[rustfmt::skip]
+                                let black_matrix: [f32; 20] = [
+                                    0.0, 0.0, 0.0, 0.0,  // R row
+                                    0.0, 0.0, 0.0, 0.0,  // G row
+                                    0.0, 0.0, 0.0, 0.0,  // B row
+                                    0.0, 0.0, 0.0, 1.0,  // A row (preserve alpha)
+                                    0.0, 0.0, 0.0, 0.0,  // Offset row
+                                ];
+                                let matrix_bytes: &[u8] = slice::from_raw_parts(
+                                    black_matrix.as_ptr() as *const u8,
+                                    size_of::<[f32; 20]>(),
+                                );
+                                color_matrix_effect
                                     .SetValue(
-                                        D2D1_SHADOW_PROP_BLUR_STANDARD_DEVIATION.0 as u32,
+                                        D2D1_COLORMATRIX_PROP_COLOR_MATRIX.0 as u32,
+                                        D2D1_PROPERTY_TYPE_MATRIX_5X4,
+                                        matrix_bytes,
+                                    )
+                                    .windows_context("color_matrix_effect.SetValue()")?;
+                                
+                                // If spread > 0, apply morphology dilation
+                                // This preserves corner shapes while expanding the shadow
+                                if effect_params.spread > 0.0 {
+                                    let morphology_effect = d2d_context
+                                        .CreateEffect(&CLSID_D2D1Morphology)
+                                        .windows_context("shadow_morphology_effect")?;
+                                    morphology_effect.SetInput(0, border_bitmap, false);
+                                    
+                                    // Set morphology mode to dilate (expand)
+                                    morphology_effect
+                                        .SetValue(
+                                            D2D1_MORPHOLOGY_PROP_MODE.0 as u32,
+                                            D2D1_PROPERTY_TYPE_ENUM,
+                                            &D2D1_MORPHOLOGY_MODE_DILATE.0.to_le_bytes(),
+                                        )
+                                        .windows_context("shadow_morphology_effect.SetValue() mode")?;
+                                    
+                                    // Set dilation size based on spread
+                                    let dilation_size = (effect_params.spread.round() as u32).max(1);
+                                    morphology_effect
+                                        .SetValue(
+                                            D2D1_MORPHOLOGY_PROP_WIDTH.0 as u32,
+                                            D2D1_PROPERTY_TYPE_UINT32,
+                                            &dilation_size.to_le_bytes(),
+                                        )
+                                        .windows_context("shadow_morphology_effect.SetValue() width")?;
+                                    morphology_effect
+                                        .SetValue(
+                                            D2D1_MORPHOLOGY_PROP_HEIGHT.0 as u32,
+                                            D2D1_PROPERTY_TYPE_UINT32,
+                                            &dilation_size.to_le_bytes(),
+                                        )
+                                        .windows_context("shadow_morphology_effect.SetValue() height")?;
+                                    
+                                    // Chain color matrix to morphology output
+                                    color_matrix_effect.SetInput(
+                                        0,
+                                        &morphology_effect
+                                            .GetOutput()
+                                            .windows_context("could not get shadow morphology output")?,
+                                        false,
+                                    );
+                                } else {
+                                    // No spread - just apply color matrix to border directly
+                                    color_matrix_effect.SetInput(0, border_bitmap, false);
+                                }
+                                
+                                // Create blur effect
+                                let blur_effect = d2d_context
+                                    .CreateEffect(&CLSID_D2D1GaussianBlur)
+                                    .windows_context("shadow_blur_effect")?;
+                                blur_effect.SetInput(
+                                    0,
+                                    &color_matrix_effect
+                                        .GetOutput()
+                                        .windows_context("could not get color_matrix output")?,
+                                    false,
+                                );
+                                
+                                // Apply blur using config's std_dev as-is
+                                blur_effect
+                                    .SetValue(
+                                        D2D1_GAUSSIANBLUR_PROP_STANDARD_DEVIATION.0 as u32,
                                         D2D1_PROPERTY_TYPE_FLOAT,
                                         &effect_params.std_dev.to_le_bytes(),
                                     )
-                                    .windows_context("shadow_effect.SetValue() std deviation")?;
-                                shadow_effect
+                                    .windows_context("shadow_blur_effect.SetValue() std deviation")?;
+                                blur_effect
                                     .SetValue(
-                                        D2D1_SHADOW_PROP_OPTIMIZATION.0 as u32,
+                                        D2D1_GAUSSIANBLUR_PROP_OPTIMIZATION.0 as u32,
                                         D2D1_PROPERTY_TYPE_ENUM,
                                         &D2D1_DIRECTIONALBLUR_OPTIMIZATION_SPEED.0.to_le_bytes(),
                                     )
-                                    .windows_context("shadow_effect.SetValue() optimization")?;
+                                    .windows_context("shadow_blur_effect.SetValue() optimization")?;
 
-                                shadow_effect
+                                blur_effect
                             }
                         };
 
@@ -308,9 +440,12 @@ impl Effects {
 pub struct EffectParamsConfig {
     #[serde(alias = "type")]
     effect_type: EffectType,
-    #[serde(alias = "radius")]
+    #[serde(alias = "blur")]
+    #[serde(alias = "radius")]  // Backwards compatibility
     #[serde(default = "serde_default_f32::<8>")]
     std_dev: f32,
+    #[serde(default)]
+    spread: f32,
     #[serde(default = "serde_default_f32::<1>")]
     opacity: f32,
     #[serde(default)]
@@ -323,6 +458,7 @@ impl EffectParamsConfig {
             effect_type: self.effect_type,
             opacity: self.opacity,
             std_dev: self.std_dev,
+            spread: self.spread,
             translation: self.translation,
         }
     }
@@ -335,6 +471,7 @@ impl EffectParamsConfig {
 pub struct EffectParams {
     pub effect_type: EffectType,
     pub std_dev: f32,
+    pub spread: f32,
     pub opacity: f32,
     pub translation: Translation,
 }

--- a/src/window_border.rs
+++ b/src/window_border.rs
@@ -302,20 +302,22 @@ impl WindowBorder {
                     .max_by_key(|params| {
                         // Try to find the effect params with the largest required padding
                         let max_std_dev = params.std_dev;
+                        let max_spread = params.spread;
                         let max_translation =
                             f32::max(params.translation.x.abs(), params.translation.y.abs());
 
                         // 3 standard deviations gets us 99.7% coverage, which should be good enough
-                        ((max_std_dev * 3.0).ceil() + max_translation.ceil()) as i32
+                        ((max_std_dev * 3.0).ceil() + max_spread.ceil() + max_translation.ceil()) as i32
                     })
                     .map(|params| {
                         // Now that we found it, go ahead and calculate it as an f32
                         let max_std_dev = params.std_dev;
+                        let max_spread = params.spread;
                         let max_translation =
                             f32::max(params.translation.x.abs(), params.translation.y.abs());
 
                         // 3 standard deviations gets us 99.7% coverage, which should be good enough
-                        (max_std_dev * 3.0).ceil() + max_translation.ceil()
+                        (max_std_dev * 3.0).ceil() + max_spread.ceil() + max_translation.ceil()
                     })
                     .unwrap_or(0.0);
                 let max_inactive_padding = self
@@ -326,18 +328,20 @@ impl WindowBorder {
                     .max_by_key(|params| {
                         // Try to find the effect params with the largest required padding
                         let max_std_dev = params.std_dev;
+                        let max_spread = params.spread;
                         let max_translation =
                             f32::max(params.translation.x.abs(), params.translation.y.abs());
 
-                        ((max_std_dev * 3.0).ceil() + max_translation.ceil()) as i32
+                        ((max_std_dev * 3.0).ceil() + max_spread.ceil() + max_translation.ceil()) as i32
                     })
                     .map(|params| {
                         // Now that we found it, go ahead and calculate it as an f32
                         let max_std_dev = params.std_dev;
+                        let max_spread = params.spread;
                         let max_translation =
                             f32::max(params.translation.x.abs(), params.translation.y.abs());
 
-                        (max_std_dev * 3.0).ceil() + max_translation.ceil()
+                        (max_std_dev * 3.0).ceil() + max_spread.ceil() + max_translation.ceil()
                     })
                     .unwrap_or(0.0);
 


### PR DESCRIPTION
Replace Gaussian blur with morphology-based approach to preserve corner shapes.

Changes:

- Shadow: morphology (dilate) + color matrix (black) + light blur

- Glow: morphology (dilate) + light blur (keeps border color)

- Add 'blur' as config alias for 'radius' (backwards compatible)

The morphology dilation expands the shape while preserving corner geometry,

then a light Gaussian blur softens edges for natural effect appearance.

Fixes #64