### PR TITLE
feat: theme-aware border colors for Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ features = [
   "Win32_System_IO",
   "Win32_System_LibraryLoader",
   "Win32_System_SystemInformation",
+  "Win32_System_Registry",
   "Win32_System_Threading",
   "Win32_Storage_FileSystem",
   "Win32_UI_Accessibility",

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -14,6 +14,7 @@ use windows::core::BOOL;
 use windows_numerics::{Matrix3x2, Vector2};
 
 use crate::LogIfErr;
+use crate::theme::is_light_theme;
 use crate::utils::WindowsCompatibleResult;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -21,6 +22,14 @@ use crate::utils::WindowsCompatibleResult;
 pub enum ColorBrushConfig {
     Solid(String),
     Gradient(GradientBrushConfig),
+    ThemeAware(ThemeAwareColor),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct ThemeAwareColor {
+    pub dark: Box<ColorBrushConfig>,
+    pub light: Box<ColorBrushConfig>,
 }
 
 impl Default for ColorBrushConfig {
@@ -81,6 +90,14 @@ pub struct GradientBrush {
 impl ColorBrushConfig {
     pub fn to_color_brush(&self, is_active_color: bool) -> ColorBrush {
         match self {
+            ColorBrushConfig::ThemeAware(theme) => {
+                let resolved = if is_light_theme() {
+                    &theme.light
+                } else {
+                    &theme.dark
+                };
+                resolved.to_color_brush(is_active_color)
+            }
             ColorBrushConfig::Solid(solid_config) => {
                 if solid_config == "accent" {
                     ColorBrush::Solid(SolidBrush {

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ use crate::colors::ColorBrushConfig;
 use crate::effects::EffectsConfig;
 use crate::komorebi::{KomorebiColorsConfig, KomorebiIntegration};
 use crate::render_backend::RenderBackendConfig;
+use crate::theme::ThemeWatcher;
 use crate::utils::{OwnedHANDLE, get_adjusted_radius, get_window_corner_preference};
 use crate::{
     APP_STATE, DirectXDevices, IS_WINDOWS_11, create_config_watcher, display_error_box,
@@ -293,6 +294,22 @@ impl Config {
                 }
 
                 {
+                    let mut theme_watcher_opt = APP_STATE.theme_watcher.lock().unwrap();
+
+                    if config.is_theme_aware_enabled() && theme_watcher_opt.is_none() {
+                        *theme_watcher_opt = ThemeWatcher::new()
+                            .inspect_err(|err| {
+                                error!("could not start theme watcher: {err:#}")
+                            })
+                            .ok();
+                    } else if !config.is_theme_aware_enabled()
+                        && theme_watcher_opt.is_some()
+                    {
+                        *theme_watcher_opt = None;
+                    }
+                }
+
+                {
                     let mut directx_devices_opt = APP_STATE.directx_devices.write().unwrap();
 
                     if config.render_backend == RenderBackendConfig::V2
@@ -338,6 +355,24 @@ impl Config {
                     .map(|komocolors| komocolors.enabled)
                     .unwrap_or(false)
             })
+    }
+
+    pub fn is_theme_aware_enabled(&self) -> bool {
+        Self::is_color_theme_aware(&self.global.active_color)
+            || Self::is_color_theme_aware(&self.global.inactive_color)
+            || self.window_rules.iter().any(|rule| {
+                rule.active_color
+                    .as_ref()
+                    .map_or(false, Self::is_color_theme_aware)
+                    || rule
+                        .inactive_color
+                        .as_ref()
+                        .map_or(false, Self::is_color_theme_aware)
+            })
+    }
+
+    fn is_color_theme_aware(config: &ColorBrushConfig) -> bool {
+        matches!(config, ColorBrushConfig::ThemeAware(_))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod iocp;
 pub mod komorebi;
 pub mod render_backend;
 pub mod sys_tray_icon;
+pub mod theme;
 pub mod utils;
 pub mod window_border;
 
@@ -21,6 +22,7 @@ use anyhow::{Context, anyhow};
 use config::{Config, ConfigWatcher, EnableMode, config_watcher_callback};
 use komorebi::KomorebiIntegration;
 use render_backend::RenderBackendConfig;
+use theme::ThemeWatcher;
 use sp_log::{ColorChoice, CombinedLogger, FileLogger, LevelFilter, TermLogger, TerminalMode};
 use std::collections::{HashMap, HashSet};
 use std::sync::{LazyLock, Mutex, OnceLock, RwLock, RwLockWriteGuard};
@@ -93,6 +95,7 @@ pub struct AppState {
     render_factory: ID2D1Factory1,
     directx_devices: RwLock<Option<DirectXDevices>>,
     komorebi_integration: Mutex<Option<KomorebiIntegration>>,
+    pub theme_watcher: Mutex<Option<ThemeWatcher>>,
     display_adapters_watcher: Mutex<Option<DisplayAdaptersWatcher>>,
 }
 
@@ -105,6 +108,7 @@ impl AppState {
 
         let config_watcher: Mutex<Option<ConfigWatcher>> = Mutex::new(None);
         let komorebi_integration: Mutex<Option<KomorebiIntegration>> = Mutex::new(None);
+        let theme_watcher: Mutex<Option<ThemeWatcher>> = Mutex::new(None);
 
         let config = match Config::create() {
             Ok(config) => {
@@ -123,6 +127,12 @@ impl AppState {
                 if config.is_komorebi_integration_enabled() {
                     *komorebi_integration.lock().unwrap() = KomorebiIntegration::new()
                         .inspect_err(|err| error!("could not start komorebi integration: {err:#}"))
+                        .ok();
+                }
+
+                if config.is_theme_aware_enabled() {
+                    *theme_watcher.lock().unwrap() = ThemeWatcher::new()
+                        .inspect_err(|err| error!("could not start theme watcher: {err:#}"))
                         .ok();
                 }
 
@@ -173,6 +183,7 @@ impl AppState {
             render_factory,
             directx_devices: RwLock::new(directx_devices_opt),
             komorebi_integration,
+            theme_watcher,
             display_adapters_watcher,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ pub struct AppState {
     render_factory: ID2D1Factory1,
     directx_devices: RwLock<Option<DirectXDevices>>,
     komorebi_integration: Mutex<Option<KomorebiIntegration>>,
-    pub theme_watcher: Mutex<Option<ThemeWatcher>>,
+    theme_watcher: Mutex<Option<ThemeWatcher>>,
     display_adapters_watcher: Mutex<Option<DisplayAdaptersWatcher>>,
 }
 

--- a/src/resources/config.yaml
+++ b/src/resources/config.yaml
@@ -79,6 +79,13 @@ global:
   #             start: [0.0, 1.0]
   #             end: [1.0, 0.0]
   #       NOTE: [0.0, 0.0] = top-left, [1.0, 1.0] = bottom-right
+  #   - Theme-aware: Define separate colors for dark/light Windows system themes
+  #       Example:
+  #         active_color:
+  #           dark: "#ffffff"
+  #           light: "#000000"
+  #       Each value (dark/light) can be a hex code, "accent", or a gradient.
+  #       Borders automatically update when the system theme changes.
   active_color:
     colors: ["#6274e7", "#8752a3"]
     direction: 45deg

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -7,7 +7,7 @@ use windows::Win32::Foundation::{
     HANDLE, WAIT_ABANDONED_0, WAIT_EVENT, WAIT_FAILED, WAIT_OBJECT_0,
 };
 use windows::Win32::System::Registry::{
-    HKEY, KEY_NOTIFY, REG_NOTIFY_CHANGE_LAST_SET, RegCloseKey, RegNotifyChangeKeyValue,
+    HKEY, KEY_NOTIFY, REG_NOTIFY_CHANGE_LAST_SET, RegNotifyChangeKeyValue,
     RegOpenKeyExW,
 };
 use windows::Win32::System::Threading::{CreateEventW, SetEvent, WaitForMultipleObjects, INFINITE};
@@ -17,7 +17,7 @@ use winreg::enums::HKEY_CURRENT_USER;
 use winreg::RegKey;
 
 use crate::reload_borders;
-use crate::utils::{OwnedHANDLE, get_last_error};
+use crate::utils::{OwnedHANDLE, OwnedHKEY, get_last_error};
 
 const PERSONALIZE_SUBKEY: &str =
     r"SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize";
@@ -42,6 +42,7 @@ pub fn is_light_theme() -> bool {
 #[derive(Debug)]
 #[allow(unused)]
 pub struct ThemeWatcher {
+    reg_key: OwnedHKEY,
     changed_event: OwnedHANDLE,
     stop_event: OwnedHANDLE,
     thread_handle: Option<JoinHandle<()>>,
@@ -68,8 +69,10 @@ impl ThemeWatcher {
         .ok()
         .context("could not open Personalize registry key for theme watcher")?;
 
+        let reg_key = OwnedHKEY(hkey);
+
         // Convert the HKEY to isize so we can move it into the new thread
-        let reg_handle_isize = hkey.0 as isize;
+        let reg_handle_isize = reg_key.0.0 as isize;
 
         let changed_event = {
             let handle = unsafe { CreateEventW(None, false, false, None)? };
@@ -152,13 +155,11 @@ impl ThemeWatcher {
                 }
             }
 
-            // Close the registry key handle since we own it
-            let _ = unsafe { RegCloseKey(reg_hkey) };
-
             debug!("exiting theme watcher thread");
         });
 
         Ok(Self {
+            reg_key,
             changed_event,
             stop_event,
             thread_handle: Some(thread_handle),

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,0 +1,188 @@
+use anyhow::Context;
+use std::iter;
+use std::thread::{self, JoinHandle};
+use std::time;
+
+use windows::Win32::Foundation::{
+    HANDLE, WAIT_ABANDONED_0, WAIT_EVENT, WAIT_FAILED, WAIT_OBJECT_0,
+};
+use windows::Win32::System::Registry::{
+    HKEY, KEY_NOTIFY, REG_NOTIFY_CHANGE_LAST_SET, RegCloseKey, RegNotifyChangeKeyValue,
+    RegOpenKeyExW,
+};
+use windows::Win32::System::Threading::{CreateEventW, SetEvent, WaitForMultipleObjects, INFINITE};
+use windows::core::PCWSTR;
+
+use winreg::enums::HKEY_CURRENT_USER;
+use winreg::RegKey;
+
+use crate::reload_borders;
+use crate::utils::{OwnedHANDLE, get_last_error};
+
+const PERSONALIZE_SUBKEY: &str =
+    r"SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize";
+const THEME_VALUE_NAME: &str = "SystemUsesLightTheme";
+
+/// Returns `true` if the Windows system theme is currently set to light mode.
+/// Defaults to `false` (dark mode) on any error.
+pub fn is_light_theme() -> bool {
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let Ok(personalize_key) = hkcu.open_subkey(PERSONALIZE_SUBKEY) else {
+        debug!("could not open Personalize registry key; defaulting to dark theme");
+        return false;
+    };
+    personalize_key
+        .get_value::<u32, _>(THEME_VALUE_NAME)
+        .unwrap_or(0)
+        == 1
+}
+
+/// Watches for Windows system theme changes by monitoring the registry.
+/// When the theme changes (dark ↔ light), it triggers a border reload.
+#[derive(Debug)]
+#[allow(unused)]
+pub struct ThemeWatcher {
+    changed_event: OwnedHANDLE,
+    stop_event: OwnedHANDLE,
+    thread_handle: Option<JoinHandle<()>>,
+}
+
+impl ThemeWatcher {
+    pub fn new() -> anyhow::Result<Self> {
+        // Open the registry key using the windows crate for RegNotifyChangeKeyValue
+        let subkey_wide: Vec<u16> = PERSONALIZE_SUBKEY
+            .encode_utf16()
+            .chain(iter::once(0))
+            .collect();
+
+        let mut hkey = HKEY::default();
+        unsafe {
+            RegOpenKeyExW(
+                HKEY(HKEY_CURRENT_USER as _),
+                PCWSTR(subkey_wide.as_ptr()),
+                Some(0),
+                KEY_NOTIFY,
+                &mut hkey,
+            )
+        }
+        .ok()
+        .context("could not open Personalize registry key for theme watcher")?;
+
+        // Convert the HKEY to isize so we can move it into the new thread
+        let reg_handle_isize = hkey.0 as isize;
+
+        let changed_event = {
+            let handle = unsafe { CreateEventW(None, false, false, None)? };
+            OwnedHANDLE(handle)
+        };
+
+        let stop_event = {
+            let handle = unsafe { CreateEventW(None, true, false, None)? };
+            OwnedHANDLE(handle)
+        };
+
+        // Convert HANDLEs to isize so we can move them into the new thread
+        let changed_handle_isize = changed_event.0 .0 as isize;
+        let stop_handle_isize = stop_event.0 .0 as isize;
+
+        let thread_handle = thread::spawn(move || {
+            debug!("entering theme watcher thread");
+
+            // Reconvert isize back to the original types
+            let reg_hkey = HKEY(reg_handle_isize as _);
+            let events = [
+                HANDLE(changed_handle_isize as _),
+                HANDLE(stop_handle_isize as _),
+            ];
+
+            const WAIT_OBJECT_1: WAIT_EVENT = WAIT_EVENT(WAIT_OBJECT_0.0 + 1);
+            const WAIT_ABANDONED_1: WAIT_EVENT = WAIT_EVENT(WAIT_ABANDONED_0.0 + 1);
+
+            let mut last_theme = is_light_theme();
+
+            loop {
+                // Register for async notification on value changes
+                let reg_result = unsafe {
+                    RegNotifyChangeKeyValue(
+                        reg_hkey,
+                        false,
+                        REG_NOTIFY_CHANGE_LAST_SET,
+                        Some(events[0]), // changed_event
+                        true,            // asynchronous
+                    )
+                };
+
+                if reg_result.is_err() {
+                    error!("RegNotifyChangeKeyValue failed: {:?}", reg_result);
+                    break;
+                }
+
+                // Wait for either a registry change or a stop signal
+                let wait_result =
+                    unsafe { WaitForMultipleObjects(&events, false, INFINITE) };
+
+                // If the stop event is signaled, exit the loop
+                if wait_result == WAIT_OBJECT_1 {
+                    break;
+                }
+
+                // If an error occurred, log it and exit the thread
+                if wait_result == WAIT_ABANDONED_0
+                    || wait_result == WAIT_ABANDONED_1
+                    || wait_result == WAIT_FAILED
+                {
+                    let last_error = get_last_error();
+                    error!("could not wait for theme changes: {last_error:?}");
+                    break;
+                }
+
+                // Registry change event signaled — check if theme actually toggled
+                let current_theme = is_light_theme();
+                if current_theme != last_theme {
+                    last_theme = current_theme;
+                    info!(
+                        "system theme changed to {}; reloading borders",
+                        if current_theme { "light" } else { "dark" }
+                    );
+
+                    // Small delay for the system to finish the theme transition
+                    thread::sleep(time::Duration::from_millis(200));
+
+                    reload_borders();
+                }
+            }
+
+            // Close the registry key handle since we own it
+            let _ = unsafe { RegCloseKey(reg_hkey) };
+
+            debug!("exiting theme watcher thread");
+        });
+
+        Ok(Self {
+            changed_event,
+            stop_event,
+            thread_handle: Some(thread_handle),
+        })
+    }
+}
+
+impl Drop for ThemeWatcher {
+    fn drop(&mut self) {
+        let set_res = unsafe { SetEvent(self.stop_event.0) };
+
+        match set_res {
+            Ok(()) => match self.thread_handle.take() {
+                Some(handle) => {
+                    if let Err(err) = handle.join() {
+                        error!("could not join theme watcher thread handle: {err:?}");
+                    }
+                }
+                None => error!("could not take theme watcher thread handle"),
+            },
+            Err(err) => error!(
+                "could not signal stop event on {:?} for theme watcher: {err:#}",
+                self.stop_event
+            ),
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,6 +19,7 @@ use windows::Win32::Graphics::Gdi::{
     GetMonitorInfoW, HMONITOR, MONITOR_DEFAULTTONEAREST, MONITORINFO, MonitorFromWindow,
 };
 use windows::Win32::System::Diagnostics::Debug::FACILITY_ITF;
+use windows::Win32::System::Registry::{HKEY, RegCloseKey};
 use windows::Win32::System::Threading::{
     OpenProcess, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION, QueryFullProcessImageNameW,
 };
@@ -381,6 +382,18 @@ pub struct OwnedHANDLE(pub HANDLE);
 impl Drop for OwnedHANDLE {
     fn drop(&mut self) {
         unsafe { CloseHandle(self.0) }
+            .with_context(|| format!("could not close {:?}", self.0))
+            .log_if_err();
+    }
+}
+
+#[derive(Debug)]
+pub struct OwnedHKEY(pub HKEY);
+
+impl Drop for OwnedHKEY {
+    fn drop(&mut self) {
+        unsafe { RegCloseKey(self.0) }
+            .ok()
             .with_context(|| format!("could not close {:?}", self.0))
             .log_if_err();
     }


### PR DESCRIPTION
- Add ThemeAware variant to ColorBrushConfig for system-level dark/light support.
- Implement ThemeWatcher module to monitor SystemUsesLightTheme registry value.
- Support separate dark and light color definitions in config.yaml.
- Ensure automatic border reloading on system theme changes.
- Maintain full backward compatibility with existing configuration formats.
- Resolve #73 by enabling system-level theme responsiveness for borders.